### PR TITLE
Link to robotframework-faker's main pypi page

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,7 +621,7 @@
             </div>
 
             <div class="link">
-              <a href="https://pypi.python.org/pypi/robotframework-faker/0.1" target="_blank">robotframework-faker</a>
+              <a href="https://pypi.python.org/pypi/robotframework-faker/" target="_blank">robotframework-faker</a>
               Library for <a href="https://github.com/joke2k/faker" target="_blank">Faker</a>, a fake test data generator.
             </div>
 


### PR DESCRIPTION
Previous link was to version 0.1 instead of the top level page.
