### PR TITLE
Add "ExcelDataDriver" library into external library

### DIFF
--- a/sources/src/App.vue
+++ b/sources/src/App.vue
@@ -272,6 +272,12 @@ export default {
                     text:
                       "Library for testing Eclipse RCP applications using SWT widgets."
                   },
+				  {
+					title: "ExcelDataDriver Library",
+					href:
+					  "https://github.com/qahive/robotframework-ExcelDataDriver",
+					text: "Excel Data-Driven Testing library for Robot Framework."
+				  },
                   {
                     title: "robotframework-faker",
                     href: "https://pypi.python.org/pypi/robotframework-faker/",

--- a/sources/src/App.vue
+++ b/sources/src/App.vue
@@ -272,12 +272,12 @@ export default {
                     text:
                       "Library for testing Eclipse RCP applications using SWT widgets."
                   },
-				  {
-					title: "ExcelDataDriver Library",
-					href:
-					  "https://github.com/qahive/robotframework-ExcelDataDriver",
-					text: "Excel Data-Driven Testing library for Robot Framework."
-				  },
+                  {
+                    title: "ExcelDataDriver Library",
+                    href:
+                      "https://github.com/qahive/robotframework-ExcelDataDriver",
+                    text: "Excel Data-Driven Testing library for Robot Framework."
+                  },
                   {
                     title: "robotframework-faker",
                     href: "https://pypi.python.org/pypi/robotframework-faker/",


### PR DESCRIPTION
Hi,
I kindly ask to add "ExcelDataDriver" as a external library.

Name: ExcelDataDriver
Short description: ExcelDataDriver is a Excel Data-Driven Testing library for RobotFramework.
Link: https://github.com/qahive/robotframework-ExcelDataDriver

Regards,
Atthaboon Sanurt