### PR TITLE
Add GitHub external link on leftside menu

### DIFF
--- a/sources/src/App.vue
+++ b/sources/src/App.vue
@@ -1509,6 +1509,13 @@ export default {
           feature_box: false
         },
         {
+          title: "GitHub",
+          text_block: true,
+          tab_box: false,
+          url: 'https://github.com/robotframework/robotframework',
+          feature_box: false
+        },
+        {
           title: "Forum",
           text_block: true,
           tab_box: false,


### PR DESCRIPTION
I was looking several times for this link to the robotframework repository on the main RF website and I always ended up with Ctrl+F searching while forgetting that it's located in the first Introduction part. I think that putting a link on the leftside menu would be very useful as a quick access to the source code.