### PR TITLE
docs: Add FastHTTPMock Library to Library repository

### DIFF
--- a/src/content/resources/libraries.mjs
+++ b/src/content/resources/libraries.mjs
@@ -107,6 +107,12 @@ export default () => ([
     description: 'Testing Eclipse RCP applications using SWT widgets.'
   },
   {
+    name: 'FastHTTPMock',
+    href: 'https://github.com/leelaprasadv/robotframework-fasthttpmock#readme',
+    description: 'HTTP mock server library for Robot Framework using FastAPI and Uvicorn',
+    tags: ['http', 'mock', 'mockserver']
+  },
+  {
     name: 'FTP library',
     href: 'https://github.com/kowalpy/Robot-Framework-FTP-Library',
     description: 'Testing and using FTP server with Robot Framework.',


### PR DESCRIPTION
**Summary**:
- Add `FastHTTPMock` library to mock external service dependencies for System/service component under test.
- Built on FastAPI and Uvicorn