### PR TITLE
Add robotframework-xmlvalidator library to resources list

### DIFF
--- a/src/content/resources/libraries.mjs
+++ b/src/content/resources/libraries.mjs
@@ -212,6 +212,12 @@ export default () => ([
     tags: ['mail', 'imap', 'smtp', 'pop3', 'ssl']
   },
   {
+    name: 'Robotframework-XmlValidator',
+    href: 'https://github.com/MichaelHallik/robotframework-xmlvalidator',
+    description: 'A Robot Framework test library for validating XML files against XSD schemas, and more.',
+    tags: ['xml', 'xsd', 'xmlschema']
+  },
+  {
     name: 'SapGuiLibrary',
     href: 'https://github.com/frankvanderkuur/robotframework-sapguilibrary/',
     description: 'Testing the SAPGUI client using the internal SAP Scripting Engine',


### PR DESCRIPTION
This pull request adds a new Robot Framework library to the ecosystem listing.

Name: Robotframework-XmlValidator
Description: A Robot Framework test library for validating XML files against XSD schemas.
Link: https://pypi.org/project/robotframework-xmlvalidator/
Source: https://github.com/MichaelHallik/robotframework-xmlvalidator

The entry has been added alphabetically to src/content/resources/libraries.mjs, following the existing format and tagging conventions.