### PR TITLE
Add robotframework-falsegreen to tools list

### DIFF
--- a/src/content/resources/tools.mjs
+++ b/src/content/resources/tools.mjs
@@ -198,6 +198,12 @@ export default () => ([
     tags: ['']
   },
   {
+    name: 'robotframework-falsegreen',
+    description: 'Find Robot Framework tests that pass green without protecting anything: no verification keyword, swallowed failures, always-true checks. Deterministic static scan via robot.api.',
+    href: 'https://github.com/vinicq/robotframework-falsegreen',
+    tags: ['']
+  },
+  {
     name: 'Robotmk',
     description: 'With Robotmk, arbitrary Robot Framework tests can be seamlessly integrated into the Checkmk monitoring tool. In addition to server and network metrics, Checkmk administrators also get worthful insights about on how well business applications are performing from the users point of view ("End-2-End Monitoring"). Robotmk can flexibly monitor and graph the runtimes of tests and keywords, and also alert when related SLAs are violated.',
     href: 'https://github.com/elabit/robotmk/',


### PR DESCRIPTION
Adds one entry to `src/content/resources/tools.mjs` for **robotframework-falsegreen**, a static-analysis tool in the Robot Framework ecosystem.

It scans Robot Framework suites for tests that pass green without actually protecting anything: tests with no verification keyword, swallowed failures, and always-true checks. The scan is deterministic and uses the official `robot.api`. Placed next to the Robocop linter entry, since both are static-analysis tools (`tags: ['']`).

- Repo: https://github.com/vinicq/robotframework-falsegreen
- PyPI: https://pypi.org/project/robotframework-falsegreen/ (`pip install robotframework-falsegreen`, CLI `rffalsegreen`)
- Docs: https://vinicq.github.io/falsegreen-docs/

Source-only change as requested in the README; the build is automatic. Description is 177 characters (under the 200 limit).